### PR TITLE
Change to port 9000

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,12 @@ export DATABASE_URL="postgresql://localhost/feedback_dev"
 * Start the server
 
 ```
-python manage.py runserver
+python manage.py server
 ```
 
-* Visit `localhost:5000` in your browser to see the results
+* Visit `localhost:9000` in your browser to see the results
 ```
-http://localhost:5000
+http://localhost:9000
 ```
 
 ### Deployment

--- a/feedback/settings.py
+++ b/feedback/settings.py
@@ -11,7 +11,7 @@ class Config(object):
     CSRF_ENABLED = True
     SECRET_KEY = 'this-really-needs-to-be-changed'
     SQLALCHEMY_DATABASE_URI = os.environ['DATABASE_URL']
-    BROWSERID_URL = 'http://localhost:5000'
+    BROWSERID_URL = 'http://localhost:9000'
     CACHE_TYPE = 'simple'  # Can be "memcached", "redis", etc.
 
 

--- a/manage.py
+++ b/manage.py
@@ -33,7 +33,7 @@ def test():
     exit_code = pytest.main([TEST_PATH, '--verbose'])
     return exit_code
 
-manager.add_command('server', Server())
+manager.add_command('server', Server(port=os.environ.get('PORT', 9000)))
 manager.add_command('shell', Shell(make_context=_make_context))
 manager.add_command('db', MigrateCommand)
 


### PR DESCRIPTION
I was getting real tired of the following server errors that would pop up:

```
127.0.0.1 - - [04/Aug/2015 10:51:07] code 400, message Bad request version ('RTSP/1.0')
127.0.0.1 - - [04/Aug/2015 10:51:07] "GET /info?txtAirPlay&txtRAOP RTSP/1.0" 400 -
```

Due to Apple Airplay there were port conflicts, so this changes local environments to use port 9000 instead of port 5000. **Note that you should now use http://localhost:9000 going forward.** You will have to close your terminal window completely and reboot your server again to get this working.
