### PR TITLE
Fixes and closes #279 and #286

### DIFF
--- a/feedback/dashboard/permits.py
+++ b/feedback/dashboard/permits.py
@@ -52,7 +52,7 @@ def lifespan_api_call(arg1=0, arg2=30, property_type='c'):
     days_0 = (datetime.date.today() - datetime.timedelta(arg1)).strftime("%Y-%m-%d")
     days_30 = (datetime.date.today() - datetime.timedelta(arg2)).strftime("%Y-%m-%d")
 
-    API = API_URL + '?$where=permit_issued_date%20%3E=%20%27' + days_30 + '%27%20AND%20permit_issued_date%20<%20%27' + days_0 + '%27%20AND%20'
+    API = API_URL + '?$where=master_permit_number=0%20AND%20permit_type=%27BLDG%27%20AND%20permit_issued_date%20%3E=%20%27' + days_30 + '%27%20AND%20permit_issued_date%20<%20%27' + days_0 + '%27%20AND%20'
     if property_type == 'h':
         API = API + 'contractor_name=%27OWNER%27'
     else:
@@ -102,12 +102,14 @@ def get_avg_cost(property_type='c'):
     property_type should either be 'r', 'h' or 'c'. Defaults to 'c'.
     Returns an integer. -1 if the API returns blank.
     '''
-    API = API_URL + '?$select=AVG(permit_total_fee)&$where='
+    API = API_URL + '?$select=AVG(permit_total_fee)&$where=master_permit_number=0%20AND%20permit_type=%27BLDG%27%20AND%20'
     if property_type == 'h':
         API = API + 'contractor_name=%27OWNER%27'
     else:
         API = API + 'residential_commercial%20=%20%27' + property_type + '%27'
-    API = API + '%20and%20co_cc_date%20IS%20NULL'
+
+    # Why do we care if the permit itself isn't closed?
+    # API = API + '%20and%20co_cc_date%20IS%20NULL'
 
     response = requests.get(API)
     result = response.json()
@@ -157,7 +159,7 @@ def api_count_call(arg1=0, arg2=30, field=''):
     days_0 = (datetime.date.today() - datetime.timedelta(arg1)).strftime("%Y-%m-%d")
     days_30 = (datetime.date.today() - datetime.timedelta(arg2)).strftime("%Y-%m-%d")
 
-    API = API_URL + '?$select=count(*)%20as%20total&$where=master_permit_number=0%20AND%20' + field + '%20%3E%20%27' + days_30 + '%27%20AND%20' + field + '%20<%20%27' + days_0 + '%27'
+    API = API_URL + '?$select=count(*)%20as%20total&$where=permit_type=%27BLDG%27%20AND%20master_permit_number=0%20AND%20' + field + '%20%3E%20%27' + days_30 + '%27%20AND%20' + field + '%20<%20%27' + days_0 + '%27'
     response = requests.get(API)
     json_result = response.json()
     return float(json_result[0]['total'])

--- a/feedback/dashboard/views.py
+++ b/feedback/dashboard/views.py
@@ -225,16 +225,12 @@ dashboard_collection = [
         "data": float(get_avg_cost('h'))
     },
     {
-        "title": "Permits issued by type, Last 30 Days",
+        "title": "Permits & sub-permits issued by type, Last 30 Days",
         "data": get_permit_types()
     },
     {
         "title": "Average age of an Open Permit (in Days)",
         "data": -1
-    },
-    {
-        "title": "Inspections Completed, Last 30 Days",
-        "data": get_master_permit_counts('last_inspection_date')
     },
     {
         "title": "Master Permits Issued, Last 30 Days",

--- a/feedback/templates/public/home.html
+++ b/feedback/templates/public/home.html
@@ -134,28 +134,10 @@
     </div>
 
     <div class='four columns panel'>
-      <div class='headline'>{{ dash_obj[12].title }}</div>
-      <div class='content-container'>
-        <p class="huge bold">{{ '{0:,}'.format(dash_obj[12].data.val) }}</p>
-        <p>Versus the same period a year ago:
-          {% if dash_obj[12].data.yoy > 0 %}
-          <span class='bold green'>Up
-          {% else %}
-          <span class='bold red'>Down
-          {% endif %}
-          {{ '%0.2f'| format(dash_obj[12].data.yoy|float) }}%
-          </span>
-        </p>
-      </div>
-      <p class='details invisible-button'><a href=#>View Details</a></p>
-    </div>
-
-    <div class='four columns panel last-panel'>
       <div class='headline'>{{ dash_obj[11].title }}</div>
       <div class='content-container'>
         <p class="huge bold">{{ '{0:,}'.format(dash_obj[11].data.val) }}</p>
-        <!--
-        <p>Versus this time a year ago:
+        <p>Versus the same period a year ago:
           {% if dash_obj[11].data.yoy > 0 %}
           <span class='bold green'>Up
           {% else %}
@@ -164,11 +146,9 @@
           {{ '%0.2f'| format(dash_obj[11].data.yoy|float) }}%
           </span>
         </p>
-      -->
       </div>
       <p class='details invisible-button'><a href=#>View Details</a></p>
     </div>
-
 
 </section> <!-- close row -->
 


### PR DESCRIPTION
The following pull request addresses #279 and #286:
- Dashboards with average time from application date to permit issuance in 30 days: now additionally filters on master BLDG permits
- Average costs of permit fees: now additionally filters on master BLDG permits. It no longer filters on open permits - it will now consider closed master BLDG permits as well
- Total master permits: now additionally filters on master BLDG permits
- Pie chart of permits by type: the header is now named "Permits & sub-permits issued by type, Last 30 Days". As a result I am NOT adding additional filtering to this.
- Permits opened per month - @phiden has this in a separate issue and I gave her the API call. Let me know if you need me to find the issue number.

@mathias-gibson & @phiden any questions?
